### PR TITLE
Add two libs to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CC		= cc
 CPPFLAGS	= -I/usr/include/infiniband
 CFLAGS		= -Wextra -Wall -Wno-unused-parameter -g -O1
 LDFLAGS		=
-LIBS		= -libnetdisc
+LIBS		= -libnetdisc -losmcomp -libmad
 
 #
 ##


### PR DESCRIPTION
On CentOS 7.3 with system IB stack, I needed to specify two additional libs.